### PR TITLE
WebSocket Backend Changes & Resizing Updates

### DIFF
--- a/backend/server.go
+++ b/backend/server.go
@@ -214,11 +214,11 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				Payload: canvasData,
 			})
 			if err != nil {
-
+				log.Println("Marshal broadcastData:", err)
 			}
 			err = conn.WriteMessage(messageType, broadcastData)
 			if err != nil {
-
+				log.Println("WriteMessage:", err)
 			}
 		default:
 			log.Println("Unknown message type:", msg.Type)

--- a/backend/server.go
+++ b/backend/server.go
@@ -1,52 +1,53 @@
 package main
 
 import (
-    "github.com/gorilla/websocket"
-    "encoding/json"
-    "net/http"
-    "log"
-    "os"
-    "sync"
-    "github.com/joho/godotenv"
+	"encoding/json"
+	"log"
 	"math/rand"
-	"time"
+	"net/http"
+	"os"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/joho/godotenv"
 )
 
 // Enums for the different drawing types
 const (
-    LINE = iota
-    CIRCLE
-    RECT
+	LINE = iota
+	CIRCLE
+	RECT
 	ERASE
 )
 
 // this struct helps us Unmarshal and Marshal the incoming JSON bytes
 // from the frontend
 type DrawCommand struct {
-    StartX int      `json:"startX"`
-    StartY int      `json:"startY"`
-    EndX   int      `json:"endX"`
-    EndY   int      `json:"endY"`
-    Type   int      `json:"type"`
+	StartX int `json:"startX"`
+	StartY int `json:"startY"`
+	EndX   int `json:"endX"`
+	EndY   int `json:"endY"`
+	Type   int `json:"type"`
 }
 
 type WebSocketMessage struct {
-	Type	string			`json:"type"`
-	Payload	json.RawMessage	`json:"payload"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
 }
 
 type Room struct {
-	clients	map[*websocket.Conn]bool
-	mu		sync.Mutex
-	canvas	[]DrawCommand
+	clients map[*websocket.Conn]bool
+	mu      sync.Mutex
+	canvas  []DrawCommand
 }
 
 var mu sync.Mutex
 var upgrader = websocket.Upgrader{
-    CheckOrigin: func(r *http.Request) bool {
-        return true
-    },
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
 }
 
 // map of current rooms
@@ -119,12 +120,12 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-    conn, err := upgrader.Upgrade(w, r, nil)
-    if err != nil {
-        log.Println("Upgrade: ", err)
-        return
-    }
-    defer conn.Close()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("Upgrade: ", err)
+		return
+	}
+	defer conn.Close()
 
 	room.mu.Lock()
 	room.clients[conn] = true
@@ -132,10 +133,10 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Client joined room %s", roomCode)
 
-    for {
-        messageType, payload, err := conn.ReadMessage()
-        if err != nil {
-            log.Println("ReadMessage: ", err)
+	for {
+		messageType, payload, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("ReadMessage: ", err)
 			room.mu.Lock()
 			delete(room.clients, conn)
 			isEmpty := len(room.clients) == 0
@@ -148,74 +149,91 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				log.Printf("Room %s deleted (empty)", roomCode)
 			}
 			log.Printf("Client disconnected from room %s", roomCode)
-            return
-        }
+			return
+		}
 
-        var msg WebSocketMessage
-        err = json.Unmarshal(payload, &msg)
-        if err != nil {
-            log.Println("Unmarshal: ", err)
-            return
-        }
+		var msg WebSocketMessage
+		err = json.Unmarshal(payload, &msg)
+		if err != nil {
+			log.Println("Unmarshal: ", err)
+			return
+		}
 		switch msg.Type {
-			case "draw":
-				var drawCommands []DrawCommand
-				err = json.Unmarshal(msg.Payload, &drawCommands)
-				if err != nil {
-					log.Println("Unmarshal DrawCommands:", err)
-					continue
-				}
-				broadcastData, err := json.Marshal(WebSocketMessage{
-					Type: "draw",
-					Payload: msg.Payload,
-				})
-				if err != nil {
-					log.Println("Marshal: ", err)
-					return
-				}
+		case "draw":
+			var drawCommands []DrawCommand
+			err = json.Unmarshal(msg.Payload, &drawCommands)
+			if err != nil {
+				log.Println("Unmarshal DrawCommands:", err)
+				continue
+			}
+			broadcastData, err := json.Marshal(WebSocketMessage{
+				Type:    "draw",
+				Payload: msg.Payload,
+			})
+			if err != nil {
+				log.Println("Marshal: ", err)
+				return
+			}
 
-				room.mu.Lock()
-				for client := range room.clients {
-					if client != conn {
-						err = client.WriteMessage(messageType, broadcastData)
-						if err != nil {
-							log.Println("WriteMessage: ", err)
-							client.Close()
-							delete(room.clients, client)
-						}
-					}
-				}
-				room.canvas = append(room.canvas, drawCommands...)
-				room.mu.Unlock()
-			case "clear-canvas":
-				broadcastData, err := json.Marshal(WebSocketMessage{ Type: "clear-canvas" })
-				if err != nil {
-					log.Println("Marshal:", err)
-					continue
-				}
-				room.mu.Lock()
-				for client := range room.clients {
+			room.mu.Lock()
+			for client := range room.clients {
+				if client != conn {
 					err = client.WriteMessage(messageType, broadcastData)
 					if err != nil {
 						log.Println("WriteMessage: ", err)
+						client.Close()
+						delete(room.clients, client)
 					}
 				}
-				room.canvas = []DrawCommand{}
-				room.mu.Unlock()
-			default:
-				log.Println("Unknown message type:", msg.Type)
+			}
+			room.canvas = append(room.canvas, drawCommands...)
+			room.mu.Unlock()
+		case "clear-canvas":
+			broadcastData, err := json.Marshal(WebSocketMessage{Type: "clear-canvas"})
+			if err != nil {
+				log.Println("Marshal:", err)
+				continue
+			}
+			room.mu.Lock()
+			for client := range room.clients {
+				err = client.WriteMessage(messageType, broadcastData)
+				if err != nil {
+					log.Println("WriteMessage: ", err)
+				}
+			}
+			room.canvas = []DrawCommand{}
+			room.mu.Unlock()
+		case "draw-all":
+			canvasData, err := json.Marshal(room.canvas)
+			if err != nil {
+				log.Println("Marshal room.canvas:", err)
+				continue
+			}
+			broadcastData, err := json.Marshal(WebSocketMessage{
+				Type:    "draw-all",
+				Payload: canvasData,
+			})
+			if err != nil {
+
+			}
+			err = conn.WriteMessage(messageType, broadcastData)
+			if err != nil {
+
+			}
+		default:
+			log.Println("Unknown message type:", msg.Type)
 		}
-    }
+	}
 }
 
 func main() {
-    log.SetFlags(0)
-    err := godotenv.Load()
-    if err != nil {
-        log.Println("failed to load env files", err)
-    }
-    port := os.Getenv("PORT")
-    host := os.Getenv("HOST")
+	log.SetFlags(0)
+	err := godotenv.Load()
+	if err != nil {
+		log.Println("failed to load env files", err)
+	}
+	port := os.Getenv("PORT")
+	host := os.Getenv("HOST")
 	corsOrigin := os.Getenv("ALLOWED_ORIGINS")
 	if corsOrigin == "" {
 		allowedOrigins = []string{
@@ -228,18 +246,18 @@ func main() {
 			allowedOrigins[i] = strings.TrimSpace(origin)
 		}
 	}
-    if (port == "" || host == "") {
-        log.Fatal("host or port env variables not defined")
-    }
+	if port == "" || host == "" {
+		log.Fatal("host or port env variables not defined")
+	}
 
-    address := host + ":" + port
-    http.HandleFunc("/ws", handleWebSocket)
+	address := host + ":" + port
+	http.HandleFunc("/ws", handleWebSocket)
 	http.HandleFunc("/create", createRoom)
 
-    log.Printf("server started at %v", address)
+	log.Printf("server started at %v", address)
 
-    err = http.ListenAndServe(address, nil)
-    if err != nil {
-        log.Fatal("ListenAndServe: ", err)
-    }
+	err = http.ListenAndServe(address, nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
 }

--- a/backend/server.go
+++ b/backend/server.go
@@ -39,6 +39,7 @@ type WebSocketMessage struct {
 type Room struct {
 	clients	map[*websocket.Conn]bool
 	mu		sync.Mutex
+	canvas	[]DrawCommand
 }
 
 var mu sync.Mutex
@@ -184,6 +185,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
+				room.canvas = append(room.canvas, drawCommands...)
 				room.mu.Unlock()
 			case "clear-canvas":
 				broadcastData, err := json.Marshal(WebSocketMessage{ Type: "clear-canvas" })
@@ -198,6 +200,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 						log.Println("WriteMessage: ", err)
 					}
 				}
+				room.canvas = []DrawCommand{}
 				room.mu.Unlock()
 			default:
 				log.Println("Unknown message type:", msg.Type)

--- a/backend/server.go
+++ b/backend/server.go
@@ -204,21 +204,26 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			room.canvas = []DrawCommand{}
 			room.mu.Unlock()
 		case "draw-all":
+			room.mu.Lock()
 			canvasData, err := json.Marshal(room.canvas)
+			room.mu.Unlock()
+
 			if err != nil {
 				log.Println("Marshal room.canvas:", err)
 				continue
 			}
 			broadcastData, err := json.Marshal(WebSocketMessage{
-				Type:    "draw-all",
+				Type:    "draw",
 				Payload: canvasData,
 			})
 			if err != nil {
 				log.Println("Marshal broadcastData:", err)
+				continue
 			}
 			err = conn.WriteMessage(messageType, broadcastData)
 			if err != nil {
 				log.Println("WriteMessage:", err)
+				continue
 			}
 		default:
 			log.Println("Unknown message type:", msg.Type)

--- a/frontend/html_template/script.js
+++ b/frontend/html_template/script.js
@@ -37,6 +37,10 @@ function resizeCanvas() {
     let width = window.innerWidth
     let height = window.innerHeight
     Module.ccall("resizeRenderer", null, ["number", "number"], [width, height])
+    if (websocket) {
+        msg = {type: "draw-all"}
+        websocket.send(JSON.stringify(msg))
+  }
 }
 
 function setActiveButton(activeButtonId) {
@@ -101,7 +105,6 @@ const resetZoom = () => {
         setTimeout(() => {
             viewportMeta.content = "width=device-width, initial-scale=1.0"
         }, 300);;
-        
     }
 }
 

--- a/frontend/html_template/script.js
+++ b/frontend/html_template/script.js
@@ -1,4 +1,5 @@
 console.log("initializing script.js")
+let resizeTimeout
 var Module = {
     preRun: [],
     postRun: [],
@@ -38,8 +39,14 @@ function resizeCanvas() {
     let height = window.innerHeight
     Module.ccall("resizeRenderer", null, ["number", "number"], [width, height])
     if (websocket) {
-        msg = {type: "draw-all"}
-        websocket.send(JSON.stringify(msg))
+        if (resizeTimeout) {
+            clearTimeout(resizeTimeout)
+        }
+        resizeTimeout = setTimeout(() => {
+            console.log("sending message to get all canvas")
+            const msg = {type: "draw-all"}
+            websocket.send(JSON.stringify(msg))
+        }, 200)
   }
 }
 

--- a/frontend/include/drawing/Shapes.h
+++ b/frontend/include/drawing/Shapes.h
@@ -23,6 +23,7 @@ void erase(
     int endY,
     int add_to_stack
 );
+void drawEntireStack();
 #ifdef __EMSCRIPTEN__
 }
 #endif

--- a/frontend/src/drawing/Shapes.cpp
+++ b/frontend/src/drawing/Shapes.cpp
@@ -57,6 +57,21 @@ void erase(
     if (add_to_stack)
         addDrawCommand(startX, startY, endX, endY, ERASE);
 }
+
+void drawEntireStack() {
+    for (int i = 0; i < drawStartX.size(); ++i) {
+        switch (drawTypes[i]) {
+            case LINE:
+                drawLine(drawStartX[i], drawStartY[i], drawEndX[i], drawEndY[i], false);
+                break;
+            case ERASE:
+                erase(drawStartX[i], drawStartY[i], drawEndX[i], drawEndY[i], false);
+                break;
+            default:
+                break;
+        }
+    }
+}
 #ifdef __EMSCRIPTEN__
 }
 #endif

--- a/frontend/src/game/GameState.cpp
+++ b/frontend/src/game/GameState.cpp
@@ -1,6 +1,7 @@
 // src/game/GameState.cpp
 #include "game/GameState.h"
 #include "drawing/DrawingCommands.h"
+#include "drawing/Shapes.h"
 #include <iostream>
 
 #ifdef __EMSCRIPTEN__
@@ -118,6 +119,9 @@ bool resizeRenderer(int width, int height) {
 
     SDL_SetWindowSize(gameState.window, width, height);
     SDL_RenderSetLogicalSize(gameState.renderer, width, height);
+
+
+    drawEntireStack();
     
     return true;
 }


### PR DESCRIPTION
## Backend Canvas Changes
- ALL draw commands are now stored per room, providing a single source of truth for each room's canvas
- A new `draw-all` message type has been added which sends all draw commands in the room to a specific client when requested

## Resizing Updates
- Resizing now initiates a timeout which triggers after 200 ms after the last window resize, sending a message to the backend with type `draw-all` which will then update the client's canvas to have all draw commands from all clients
- If not connected to a room, then the C++ module simply redraws all client draw commands